### PR TITLE
[FIX][REF] use public_url

### DIFF
--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -269,6 +269,7 @@ class SaasPortalPlan(models.Model):
                                                        DEFAULT_SERVER_DATETIME_FORMAT) + timedelta(hours=self.expiration)).strftime(DEFAULT_SERVER_DATETIME_FORMAT)  # for trial
         state = {
             'd': client.name,
+            'public_url': client.public_url,
             'e': trial and trial_expiration_datetime or client.create_date,
             'r': client.public_url + 'web',
             'owner_user': owner_user_data,
@@ -448,6 +449,7 @@ class SaasPortalDatabase(models.Model):
         state = {
             'd': r.name,
             'host': r.host,
+            'public_url': r.public_url,
             'client_id': r.client_id,
         }
         url = r.server_id._request(path=path, state=state, client_id=r.client_id)

--- a/saas_server/controllers/main.py
+++ b/saas_server/controllers/main.py
@@ -38,6 +38,7 @@ class SaasServer(http.Controller):
         state = simplejson.loads(post.get('state'))
         owner_user = state.get('owner_user')
         new_db = state.get('d')
+        public_url = state.get('public_url')
         trial = state.get('t')
         expiration_db = state.get('e')
         template_db = state.get('db_template')
@@ -85,9 +86,7 @@ class SaasServer(http.Controller):
             oauth_provider_id = client_env.ref('saas_client.saas_oauth_provider').id
             action_id = client_env.ref(action).id
 
-        port = self._get_port()
-        scheme = request.httprequest.scheme
-        url = '{scheme}://{domain}:{port}/saas_client/new_database'.format(scheme=scheme, domain=new_db, port=port)
+        url = '{public_url}saas_client/new_database'.format(public_url=public_url)
         return simplejson.dumps({
             'url': url,
             'state': simplejson.dumps({
@@ -103,17 +102,15 @@ class SaasServer(http.Controller):
     def edit_database(self, **post):
         _logger.info('edit_database post: %s', post)
 
-        scheme = request.httprequest.scheme
-        port = self._get_port()
         state = simplejson.loads(post.get('state'))
-        domain = state.get('host')
+        public_url = state.get('public_url')
 
         params = {
             'access_token': post['access_token'],
             'state': simplejson.dumps(state),
         }
-        url = '{scheme}://{domain}:{port}/saas_client/edit_database?{params}'
-        url = url.format(scheme=scheme, domain=domain, port=port, params=werkzeug.url_encode(params))
+        url = '{public_url}saas_client/edit_database?{params}'
+        url = url.format(public_url=public_url, params=werkzeug.url_encode(params))
         return werkzeug.utils.redirect(url)
 
     @http.route('/saas_server/upgrade_database', type='http', auth='public')
@@ -284,10 +281,6 @@ class SaasServer(http.Controller):
                 'total_storage_limit': client.total_storage_limit,
             })
         return simplejson.dumps(res)
-
-    def _get_port(self):
-        host_parts = request.httprequest.host.split(':')
-        return len(host_parts) > 1 and host_parts[1] or 80
 
     def _get_message(self, dbuuid):
         message = False


### PR DESCRIPTION
it fixes errors on runbot;

Traceback (most recent call last):
  File "/mnt/odoo-extra/runbot/static/build/01313-393-0c9ac4/saas.py", line 187, in main
    rpc_run_tests(args.get('portal_db_name'), plan_id)
  File "/mnt/odoo-extra/runbot/static/build/01313-393-0c9ac4/saas.py", line 373, in rpc_run_tests
    requests.get(create_new_database.get('url'))
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 60, in get
    return request('get', url, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 49, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 457, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 595, in send
    history = [resp for resp in gen] if allow_redirects else []
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 189, in resolve_redirects
    allow_redirects=False,
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 569, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/adapters.py", line 420, in send
    raise SSLError(e, request=request)
SSLError: hostname '01313-393-0c9ac4--base---client-001' doesn't match either of '*.it-projects.info', 'it-projects.info'