### PR TITLE
[IMP] no need to create db explicitly in 9.0+

### DIFF
--- a/saas.py
+++ b/saas.py
@@ -211,12 +211,6 @@ def createdb(dbname, install_modules=['base']):
     if args.get('drop_databases'):
         pg_dropdb(dbname)
 
-    # create db if not exist
-    try:
-        pg_createdb(dbname, without_demo=without_demo)
-    except Exception, e:
-        log('pg_createdb error:', e)
-
     cmd = get_cmd(dbname, workers=0)
     cmd += ['-i', ','.join(install_modules)]
     if args.get('test_enable'):


### PR DESCRIPTION
The database will created on running with --database and -i args.

This allows to don't skip _initialize_db method which is used by by
scripts from https://github.com/it-projects-llc/install-odoo