### PR TITLE
[CI] saas.py: allow arbitrary odoo params

### DIFF
--- a/saas.py
+++ b/saas.py
@@ -486,6 +486,9 @@ def get_cmd(dbname='', workers=3, run_cron=False):
     if args.get('addons_path'):
         cmd += ['--addons-path=%s' % args.get('addons_path')]
 
+    if os.getenv('SAAS_ODOO_PARAMS'):
+        cmd += os.getenv('SAAS_ODOO_PARAMS').split(' ')
+
     return cmd
 
 


### PR DESCRIPTION
e.g. to specify --log-handler for boto3 in the module https://github.com/it-projects-llc/misc-addons/blob/10.0/ir_attachment_s3/