### PR TITLE
[FIX] add /odoo-saas-tools/ prefix, because original theme is made for

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ markdown: kramdown
 highlighter: rouge
 exclude: ["less","node_modules","Gruntfile.js","package.json","README.md"]
 port: 8888
-permalink: /blog/:title
+permalink: /odoo-saas-tools/blog/:title
 
 # jekyll-paginate. for paginating blog posts.
 paginate: 5

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Page Header -->
-<header class="intro-header" style="background-image: url('{{ page.header-img }}')">
+<header class="intro-header" style="background-image: url('/odoo-saas-tools/{{ page.header-img }}')">
     <div class="container">
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Post Header -->
-<header class="intro-header" style="background-image: url('{{ page.header-img }}')">
+<header class="intro-header" style="background-image: url('/odoo-saas-tools/{{ page.header-img }}')">
     <div class="container">
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">


### PR DESCRIPTION
username.github.io repositories, rather than for gh-pages branch