### PR TITLE
[CI] add website-addons

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,2 +1,3 @@
 e-commerce https://github.com/OCA/e-commerce
 access-addons https://github.com/it-projects-llc/access-addons
+website-addons https://github.com/it-projects-llc/website-addons


### PR DESCRIPTION
due to:

except_orm: ('Error', u"You try to install module 'saas_portal_demo' that depends on module 'website_seo_url'.\nBut the latter module is not available in your system.")