### PR TITLE
[IMP] saas_portal: saas_portal.client needs plan_id only to count how…

### DIFF
--- a/saas_portal/models/saas_portal.py
+++ b/saas_portal/models/saas_portal.py
@@ -590,7 +590,7 @@ class SaasPortalClient(models.Model):
 
     name = fields.Char(required=True)
     partner_id = fields.Many2one('res.partner', string='Partner', track_visibility='onchange', readonly=True)
-    plan_id = fields.Many2one('saas_portal.plan', string='Plan', track_visibility='onchange', ondelete='restrict', readonly=True)
+    plan_id = fields.Many2one('saas_portal.plan', string='Plan', track_visibility='onchange', ondelete='set null', readonly=True)
     expiration_datetime = fields.Datetime(string="Expiration")
     expired = fields.Boolean('Expired')
     user_id = fields.Many2one('res.users', default=lambda self: self.env.user, string='Salesperson')


### PR DESCRIPTION
… many clients of this plan has a user. This field is not mandatory and shouldn't prevent to delete plan record