### PR TITLE
[FIX] saas_portal: fix `Expected singleton: saas.config()`. `do_upgra…

### DIFF
--- a/saas_portal/wizard/config_wizard.py
+++ b/saas_portal/wizard/config_wizard.py
@@ -70,7 +70,6 @@ class SaasConfig(models.TransientModel):
 
     @api.model
     def do_upgrade_database(self, payload, database_record):
-        self.ensure_one()
         state = {
             'data': payload,
         }


### PR DESCRIPTION
…de_database` is an `api.model` - there shouldn't by any `ensure_one`