### PR TITLE
[11.0] [FIX] 'website' object has no attribute 'render'

### DIFF
--- a/saas_portal_templates/controllers/main.py
+++ b/saas_portal_templates/controllers/main.py
@@ -13,7 +13,7 @@ class SaasPortalTemplates(saas_portal_controller):
         fields = ['id', 'name', 'summary']
         templates = request.env['saas_portal.plan'].sudo().search_read(domain=domain, fields=fields)
         values = {'templates': templates}
-        return request.website.render("saas_portal_templates.select_template", values)
+        return request.render("saas_portal_templates.select_template", values)
 
     @http.route(['/saas_portal_templates/new_database'], type='http', auth='public', website=True)
     def new_database(self, **post):


### PR DESCRIPTION
@yelizariev The render method is removed from the website, it is deprecated. Now directly request,render is used!

Please find the PR which explains that change  

https://github.com/odoo/odoo/commit/8a399930f316fc4d65828441d86301d4a8dfa669