### PR TITLE
[FIX] saas_portal, saas_server: move icon from 2nd level to 1st level menu

### DIFF
--- a/saas_portal/views/saas_portal.xml
+++ b/saas_portal/views/saas_portal.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-        <menuitem name="SaaS" id="menu_base_saas" sequence="30" />
-        <menuitem id="menu_saas" parent="menu_base_saas" name="SaaS" sequence="1" web_icon="saas_portal,static/description/icon.png" />
+        <menuitem name="SaaS" id="menu_base_saas" sequence="30" web_icon="saas_portal,static/description/icon.png"/>
+        <menuitem id="menu_saas" parent="menu_base_saas" name="SaaS" sequence="1"/>
         <menuitem id="menu_saas_portal_config"
             name="Configuration"
             parent="menu_base_saas"

--- a/saas_server/views/saas_server.xml
+++ b/saas_server/views/saas_server.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem name="SaaS Server" id="menu_base_saas" sequence="30"/>
-    <menuitem id="menu_saas" parent="menu_base_saas" name="SaaS" sequence="1" web_icon="saas_server,static/description/icon.png"/>
+    <menuitem name="SaaS Server" id="menu_base_saas" sequence="30" web_icon="saas_server,static/description/icon.png"/>
+    <menuitem id="menu_saas" parent="menu_base_saas" name="SaaS" sequence="1"/>
     <menuitem id="menu_saas_server_config" name="Configuration" parent="menu_base_saas" sequence="6" groups="base.group_system"/>
     <!-- Client -->
     <!-- TODO create some template to unduplicate this source with one in saas_portal -->


### PR DESCRIPTION
Hi,

I've moved icons from 2nd to 1st level menu to view them when module OCA/web/web_responsive is installed:

![icon](https://user-images.githubusercontent.com/39995504/43883617-fdc7f22c-9bb3-11e8-95ee-90fea6dafd47.png)

Thanks!