### PR TITLE
Fix   #806 - Create "A" instead of "CNAME" record for Client in route53

### DIFF
--- a/saas_sysadmin_route53/models/saas_sysdamin_route53.py
+++ b/saas_sysadmin_route53/models/saas_sysdamin_route53.py
@@ -33,7 +33,7 @@ class SaasPortalClient(models.Model):
     def create(self, vals):
         client = super(SaasPortalClient, self).create(vals)
         if client.server_id.aws_hosted_zone_id:
-            client.server_id._update_zone(client.name, value=client.server_id.name, type='cname')
+            client.server_id._update_zone(client.name, value=client.server_id.ip_address, type='a')
         return client
 
     @api.multi
@@ -42,8 +42,8 @@ class SaasPortalClient(models.Model):
             if 'server_id' in vals:
                 server = self.env['saas_portal.server'].browse(vals['server_id'])
                 if client.server_id.aws_hosted_zone_id and server.id != client.server_id.id:
-                    client.server_id._update_zone(client.name, value=client.server_id.name,
-                                                  type='cname', action='update')
+                    client.server_id._update_zone(client.name, value=client.server_id.ip_address,
+                                                  type='a', action='update')
         super(SaasPortalClient, self).write(vals)
         return True
 
@@ -51,5 +51,5 @@ class SaasPortalClient(models.Model):
     def unlink(self):
         for client in self:
             if client.server_id.aws_hosted_zone_id:
-                client.server_id._update_zone(client.name, type='cname', action='delete')
+                client.server_id._update_zone(client.name, type='a', action='delete')
         return super(SaasPortalClient, self).unlink()


### PR DESCRIPTION
Solves issue #806 for mailgun and route53 users

Creating an A record instead of a CNAME record for the client, in route53, avoids error when  automatically creating mailgun verification MX record for client database.
The problem with this fix, is that before applying it, existing CNAME records of clients, should be 
changed to A records, with the IP address of their respective servers. Because of this, I am not sure if this fix should be merged.
Congratulations for your great work.