### PR TITLE
[ADD] saas_server_backup_ftp field port for ssh

### DIFF
--- a/saas_server_backup_ftp/models/res_config.py
+++ b/saas_server_backup_ftp/models/res_config.py
@@ -24,6 +24,10 @@ class SaasPortalConfigWizard(models.TransientModel):
         string='Username on SFTP Server',
         help='''The username where the SFTP connection should be made with.
         This is the user on the external server.''')
+    sftp_port = fields.Integer(
+        string='Port on SFTP Server', default="22",
+        help='''The port where the SFTP connection should be made with.
+        This is the port on the external server.''')
     sftp_password = fields.Char(
         string='Password User SFTP Server',
         help='''The password from the user where the SFTP connection should be
@@ -51,6 +55,7 @@ class SaasPortalConfigWizard(models.TransientModel):
         ICPSudo = self.env['ir.config_parameter'].sudo()
         ICPSudo.set_param("saas_server.sftp_server", self.sftp_server)
         ICPSudo.set_param("saas_server.sftp_username", self.sftp_username)
+        ICPSudo.set_param("saas_server.sftp_port", self.sftp_port)
         ICPSudo.set_param("saas_server.sftp_password", self.sftp_password)
         ICPSudo.set_param("saas_server.sftp_path", self.sftp_path)
         ICPSudo.set_param("saas_server.rsa_key_path", self.rsa_key_path)
@@ -64,6 +69,7 @@ class SaasPortalConfigWizard(models.TransientModel):
         res.update(
             sftp_server=ICPSudo.get_param('saas_server.sftp_server'),
             sftp_username=ICPSudo.get_param('saas_server.sftp_username'),
+            sftp_port=int(ICPSudo.get_param('saas_server.sftp_port')),
             sftp_password=ICPSudo.get_param('saas_server.sftp_password'),
             sftp_path=ICPSudo.get_param('saas_server.sftp_path'),
             rsa_key_path=ICPSudo.get_param('saas_server.rsa_key_path'),
@@ -76,6 +82,7 @@ class SaasPortalConfigWizard(models.TransientModel):
         params = {
             "host": self.sftp_server,
             "username": self.sftp_username,
+            "port": int(self.sftp_port),
         }
 
         try:

--- a/saas_server_backup_ftp/models/saas_server.py
+++ b/saas_server_backup_ftp/models/saas_server.py
@@ -22,6 +22,7 @@ class SaasServerClient(models.Model):
         server = ICPSudo.get_param('saas_server.sftp_server', None)
         username = ICPSudo.get_param('saas_server.sftp_username', None)
         password = ICPSudo.get_param('saas_server.sftp_password', None)
+        port = int(ICPSudo.get_param('saas_server.sftp_port', 22))
         path = ICPSudo.get_param('saas_server.sftp_path', None)
         rsa_key_path = ICPSudo.get_param('saas_server.rsa_key_path', None)
         rsa_key_passphrase=ICPSudo.get_param('saas_server.rsa_key_passphrase')
@@ -30,6 +31,7 @@ class SaasServerClient(models.Model):
         params = {
             "host": server,
             "username": username,
+            "port": port,
         }
         if rsa_key_path:
             params["private_key"] = self.rsa_key_path

--- a/saas_server_backup_ftp/views/res_config.xml
+++ b/saas_server_backup_ftp/views/res_config.xml
@@ -25,6 +25,13 @@
           </div>
           <div class="col-xs-12 col-md-6 o_setting_box">
             <div>
+              <label for="sftp_port"/>
+              <div class="text-muted">The port where the SFTP connection should be made with. This is the port on the external server.</div>
+              <field name="sftp_port" placeholder="22"/>
+            </div>
+          </div>
+          <div class="col-xs-12 col-md-6 o_setting_box">
+            <div>
               <label for="sftp_password"/>
               <div class="text-muted">The password from the user where the SFTP connection should be made with. This is the password from the user on the external server.</div>
               <field name="sftp_password" password="True"/>


### PR DESCRIPTION
Some ssh connection need a different port than 22. It can be specify now with this added field.